### PR TITLE
Return false on conference-not-found

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func getConfName(db *sql.DB, confId int) string {
 			"confId": confId,
 			"err":    err,
 		}).Error("Could not query conf name from db")
-		return ""
+		return "false"
 	}
 	return result
 }


### PR DESCRIPTION
If no conference is found, the API docs expect a boolean false:
https://github.com/jitsi/jitsi-meet/blob/master/resources/cloud-api.swagger

As unions / sum types (string or boolean) is hard in golang,
for now at least return string "false", with jq -r as post-processing this
is stripped to false without quotes anyway.

This matches with the asterisk dialplan check at
https://github.com/freifunkMUC/ffmuc-salt-public/blob/master/jitsi/asterisk/extensions.conf.jinja#L11